### PR TITLE
MO : Deduction of amount already paid

### DIFF
--- a/cheque.php
+++ b/cheque.php
@@ -171,10 +171,11 @@ class Cheque extends PaymentModule
 			return;
 
 		$state = $params['objOrder']->getCurrentState();
+		$rest_to_paid = $params['objOrder']->getOrdersTotalPaid() - $params['objOrder']->getTotalPaid();
 		if (in_array($state, array(Configuration::get('PS_OS_CHEQUE'), Configuration::get('PS_OS_OUTOFSTOCK'), Configuration::get('PS_OS_OUTOFSTOCK_UNPAID'))))
 		{
 			$this->smarty->assign(array(
-				'total_to_pay' => Tools::displayPrice($params['total_to_pay'], $params['currencyObj'], false),
+				'total_to_pay' => Tools::displayPrice($rest_to_paid, $params['currencyObj'], false),
 				'chequeName' => $this->chequeName,
 				'chequeAddress' => Tools::nl2br($this->address),
 				'status' => 'ok',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | An order can have other payment on the same order process we can have a payment that is made before (eg payment by gift card or balance / have), so it is necessary to deduct the amount that has already been paid. This update have visual impact for the final customer. I regularly implement this update near my clients.
Maybe one day we will be able to make multiple payments, this update is a first step :-).
| Type?         | Feature
| Category?     | MO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  |  Paid with check payment and check iamount
